### PR TITLE
Fix invalid activity by week

### DIFF
--- a/tracstats/web_ui.py
+++ b/tracstats/web_ui.py
@@ -523,11 +523,8 @@ class TracStatsPlugin(Component):
         for _, t, author, _, _ in revisions:
             if t > start:
                 week = time.strftime('%Y-%W', time.localtime(t))
-                try:
-                    d[author][week] += 1
-                except KeyError:
-                    d[author] = { week : 1 }
-
+                d.setdefault(author, {}).setdefault(week, 0)
+                d[author][week] += 1
         stats = []
         for i, author in enumerate(sorted(set(author for _, _, author, _, _ in revisions))):
             commits = len(set(x[0] for x in revisions if x[2] == author))


### PR DESCRIPTION
The original implementation led to reset the commit counter but with the last active week